### PR TITLE
test: refactor SmartTvTest and add new tests for channel behavior

### DIFF
--- a/common/src/test/java/edu/ntnu/sveiap/idata2304/smarttv/common/logic/SmartTvTest.java
+++ b/common/src/test/java/edu/ntnu/sveiap/idata2304/smarttv/common/logic/SmartTvTest.java
@@ -26,7 +26,7 @@ class SmartTvTest {
   @Test
   void usingChannelWhileOffIsIllegal() {
     SmartTv smartTv = new SmartTv(10);
-    assertThrows(IllegalStateException.class, () -> smartTv.getChannel());
+  assertThrows(IllegalStateException.class, smartTv::getChannel);
     assertThrows(IllegalStateException.class, () -> smartTv.setChannel(1));
   }
 
@@ -68,5 +68,28 @@ class SmartTvTest {
 
     tv.channelDown(); // 2
     assertEquals(2, tv.getChannel());
+  }
+
+  /**
+   * Idempotent on/off and getNumberOfChannels while off should throw.
+   */
+  @Test
+  void idempotentPowerAndChannelCountGuard() {
+    SmartTv tv = new SmartTv(4);
+    // getNumberOfChannels while OFF
+  IllegalStateException ex1 = assertThrows(IllegalStateException.class, tv::getNumberOfChannels);
+  // ensure reason is TV_OFF
+  assertEquals("TV_OFF", ex1.getMessage());
+    // turnOn twice
+    tv.turnOn();
+    tv.turnOn();
+    // now channel count accessible
+    assertEquals(4, tv.getNumberOfChannels());
+    // turnOff twice
+    tv.turnOff();
+    tv.turnOff();
+    // again guarded
+    IllegalStateException ex2 = assertThrows(IllegalStateException.class, tv::getNumberOfChannels);
+    assertEquals("TV_OFF", ex2.getMessage());
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,3 +257,73 @@ Manual smoke (README)
 - EVT: Server-initiated event line (e.g., `EVT CHANNEL <n>`).
 - SUB/UNSUB: Subscribe/unsubscribe to events on the current connection.
 - Adapter: Glue translating protocol messages to logic calls (and back).
+
+---
+
+## 19) Klassediagram (oversikt)
+
+PlantUML-kilde (logiske klasser og relasjoner). Dette er en lettvektsmodell – detaljer som alle metodesignaturer i `Codec` er forkortet for lesbarhet.
+
+```plantuml
+@startuml
+skinparam classAttributeIconSize 0
+skinparam linetype ortho
+
+legend left
+  Relationship typer:
+  *--  Komposisjon (eier livssyklus)
+  -->  Direkte avhengighet (felt / sterk bruk)
+  ..>  Løs kobling / bruker statiske metoder
+endlegend
+
+package common {
+  class TvState {
+    - boolean on
+    - int channels
+    - int currentChannel
+    + isOn()
+    + getChannelRange()
+    + getCurrentChannel()
+    + setOn(boolean)
+    + setCurrentChannel(int)
+  }
+  class SmartTv {
+    - TvState tvState
+    + turnOn()
+    + turnOff()
+    + isOn()
+    + getNumberOfChannels()
+    + getChannel()
+    + setChannel(int)
+    + channelUp()
+    + channelDown()
+  }
+  class Codec {
+    {static} parseRequest(line)
+    {static} ok()/okStatus()/okChannels()/okChannel()/okPong()
+    {static} errBadCommand()/errTvOff()/errOutOfRange()/errInvalidState()/errServerError()
+  }
+  enum Command
+  class Request {
+    + command : Command
+    + arg : Integer
+  }
+}
+package "tv-server" {
+  class ProtocolHandler {
+    - SmartTv tv
+    + handleLine(String)
+  }
+}
+
+SmartTv *-- "1" TvState : eier
+ProtocolHandler --> "1" SmartTv : delegasjon
+ProtocolHandler ..> Codec : formattering/parsing
+Codec ..> Command : referanse
+Codec ..> Request : produserer
+Request --> Command : felt
+@enduml
+```
+
+Generering: bruk PlantUML-plugin i IDE, eller kjør en ekstern PlantUML-renderer.
+

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,23 +6,6 @@
 
 ---
 
-## Run Powershell script (./tools/run-all.ps1)
-```powershell
-powershell -ExecutionPolicy Bypass -File tools/run-all.ps1
-# or with options
-powershell -ExecutionPolicy Bypass -File tools/run-all.ps1 -ServerHost 127.0.0.1 -Port 1238 -Rebuild
-```
-
-## windows terminal
-powershell -ExecutionPolicy Bypass -File tools/run-wt.ps1
-
-## Two-seperate windows
-```powershell
-powershell -ExecutionPolicy Bypass -File tools/run-two-windows.ps1
-# or with options
-powershell -ExecutionPolicy Bypass -File tools/run-two-windows.ps1 -ServerHost 127.0.0.1 -Port 1238 -Rebuild
-```
-
 # Manual excecution steps to run server/client
 
 ## 0) Build everything
@@ -32,17 +15,27 @@ mvn -q -DskipITs clean install
 
 ## 1) Start the TV server (Terminal A)
 # Recommended
+```
 mvn -q -f tv-server/pom.xml exec:java "-Dexec.args=--port 1238"
+```
 
 # If PowerShell ever mangles the args, use stop-parsing:
+```
 mvn --% -q -f tv-server/pom.xml exec:java -Dexec.args=--port 1238
+```
 
 # This should appear in the teminal
+```
 [TvServerApp] Starting on port 1238
 [TcpServer] Listening on port 1238...
+```
 
 ## Start remote client (Terminal B)
+```
 mvn -q -f remote-client/pom.xml exec:java "-Dexec.args=127.0.0.1 1238"
+```
 
 # This should appear in the terminal
+```
 smarttv>
+```

--- a/docs/fremdriftsplan.md
+++ b/docs/fremdriftsplan.md
@@ -23,13 +23,13 @@
 - [x] Commit + tag `v0.1.0-simple`
 
 ## Uke 39 — Del 2: Refaktorering & enhetstester
-- [ ] Sjekk lagdeling: `logic` uavhengig av `protocol`/`transport`  
-- [ ] Gjør meldinger/kommandoer lett å endre (sentraliser i `protocol`)  
-- [ ] **Tester (common/logic):** minst 3 (TV OFF default, valid/invalid channel, state rules)  
-- [ ] **Tester (protocol/codec):** parsing av gyldige/ugyldige meldinger, feilkoder  
-- [ ] **Tester (server/adapter):** kommando → stateendring (uten ekte sockets hvis mulig)  
-- [ ] Oppdater `architecture.md` med klassediagram (enkelt)  
-- [ ] Commit + tag `v0.2.0-refactor-tests`
+- [x] Sjekk lagdeling: `logic` uavhengig av `protocol`/`transport` 
+- [x] Gjør meldinger/kommandoer lett å endre (sentraliser i `protocol`)  
+- [x] **Tester (common/logic):** minst 3 (TV OFF default, valid/invalid channel, state rules) 
+- [x] **Tester (protocol/codec):** parsing av gyldige/ugyldige meldinger, feilkoder 
+- [x] **Tester (server/adapter):** kommando → stateendring (uten ekte sockets hvis mulig) 
+- [x] Oppdater `architecture.md` med klassediagram (enkelt)  
+- [ ] Commit + tag `v0.2.0-refactor-tests`  
 
 ## Uke 40 — Robusthet & feilhandtering
 - [ ] Normaliser feilkoder (`400/401/404/409/500`) i server-svar  


### PR DESCRIPTION
- Updated `usingChannelWhileOffIsIllegal` test to use method reference for clarity.
- Added `idempotentPowerAndChannelCountGuard` test to verify behavior of SmartTv when powered off, ensuring it throws exceptions for channel access and validates state after power toggles.

test: enhance CodecTest with additional response formats

- Added tests for various OK responses in `formatsOtherOkResponses`.
- Added tests for error responses in `formatsErrorResponses`.
- Added tests for parsing commands in `parsesOtherNoArgCommands`.
- Added tests for trimming and space normalization in `trimsAndCollapsesSpaces`.
- Added test for rejecting overly long command lines in `rejectsTooLongLine`.

docs: update architecture documentation with class diagram

- Added a class diagram to `architecture.md` to illustrate logical classes and relationships within the Smart-TV architecture.

docs: refine commands documentation

- Removed outdated PowerShell script execution instructions from `commands.md`.
- Updated instructions for starting the TV server and remote client with clearer examples.

docs: update progress plan

- Marked tasks as completed in `fremdriftsplan.md` for refactoring and unit testing.